### PR TITLE
Breaks clone and permissions task in separate ones

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,8 +43,14 @@
         dest: "{{ pihole_directory }}"
         depth: "{{ pihole_repo_depth }}"
         version: "{{ pihole_branch }}"
-      become_user: "{{ pihole_user }}"
-      become: true
+
+    - name: fix file permissions
+      file:
+        path: "{{ pihole_directory }}"
+        state: directory
+        recurse: yes
+        owner: "{{ pihole_user }}"
+        group: "{{ pihole_group }}"
 
     - name: check if pihole etc dir exists
       stat:


### PR DESCRIPTION
While running the service, there were permission issues related to
cloning pihole as unpriviledged users. I could not get around this and I
am not sure this was an issue with my setup or maybe changes to the
distro and the only way that this worked was breaking the clone task
into two separated ones.

Task #1 clones pihole repository and task #2 changes the folder
permissions to pihole user and group previously created. This approach
seems to have worked with no problems and the playbook completed
successfully.